### PR TITLE
Fix auth refresh fails & redundant request + improvements

### DIFF
--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -31,7 +31,10 @@ export const instance = axios.create({
 /* Error responses that are not 400s should be errors in the request chain */
 instance.interceptors.response.use(
   (res) => (res.data.error ? Promise.reject(res.data) : res),
-  (err) => Promise.reject(err),
+  (err) => {
+    console.warn(err);
+    return Promise.reject(err);
+  },
 );
 
 //


### PR DESCRIPTION
The authentication logic seemed to have multiple faults in it:

- React query no longer retries requests on 401s.
- Parallel requests that fail will all fire parallel refresh requests.
- Failed refresh on verify retriggers another verify request.

Some changes have been made:

+ Store and use the current refresh request promise to prevent duplicate refresh requests.
- Remove old logic with timers on refresh requests.
* Improve verify request triggering from Auth.tsx and refactor login/logout actions.
+ All axios errors are now logged to console, no need to log errors in login/logout handlers.
* Fix and simplify the retry logic for react query and use the new on success boolean to make sure that successfull refresh request always triggers a new retry.