### PR TITLE
Persisting Portal Filters

### DIFF
--- a/web/src/components/DataTable/DataTableFilterMultiSelect.tsx
+++ b/web/src/components/DataTable/DataTableFilterMultiSelect.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import * as U from '@utils';
 import { EnumAttributes } from '@data/enums';
 import MultiSelect from '@components/MultiSelect';
 
 import { Row, useDataTable, useFilterPopover } from './';
+
+import usePersistentState from '@hooks/usePersistentState';
+import usePortalSlugs from '@hooks/useSlugs';
 
 export interface FilterMultiSelectProps {
   /* Used to register the built in filter function with DataTable */
@@ -24,7 +27,11 @@ export const FilterMultiSelect = ({
   heading,
   initSelected = [],
 }: FilterMultiSelectProps) => {
-  const [selected, setSelected] = useState<string[]>(initSelected);
+  const { appSlug, pageSlug } = usePortalSlugs();
+  const [selected, setSelected] = usePersistentState(
+    `${appSlug}-${pageSlug}-${filterKey}-multiSelectFilter`,
+    initSelected,
+  );
   const { setActiveLabels } = useFilterPopover();
 
   const { filterFnMap, setFilterFn, rawData } = useDataTable({

--- a/web/src/hooks/useSlugs.ts
+++ b/web/src/hooks/useSlugs.ts
@@ -3,21 +3,23 @@ import { useLocation } from 'react-router-dom';
 export default function usePortalSlugs(): {
   url: string;
   baseUrl: string;
-  coreUrl?: string;
-  appSlug?: string;
+  coreUrl: string;
+  appSlug: string;
+  pageSlug: string;
   tailSlug?: string;
 } {
   const location = useLocation();
-  const match = location.pathname.match(/^(\/[^/]+)(?:(\/[^/]+))?(\/.*)?/);
+  const match = location.pathname.match(/^(\/[^/]+)(\/[^/]+)(\/[^/]+)?(\/.*)?/);
 
   if (!match) throw new Error('useSlugs failed to match the location pathname');
 
-  const [url, baseUrl, appSlug, tailSlug] = match;
+  const [url, baseUrl, appSlug, pageSlug, tailSlug] = match;
 
   return {
     url,
     baseUrl,
     appSlug,
+    pageSlug,
     tailSlug,
     coreUrl: baseUrl + appSlug,
   };


### PR DESCRIPTION
feat (web): Filters for the Portal were persisted. This is done so that users of the portal don't have to get annoyed when they switch tabs or which section they are working in. This was done by creating two new functions that return usePersistentState. Then by using these functions in place of useState we make those states into persistent states. A useEffect also had to be used to make the FilterSearch work.