### PR TITLE
fix(web): Cannot Edit Vehicles; regTag Unique applies in edit mode

### DIFF
--- a/web/src/data/vehicle/form.ts
+++ b/web/src/data/vehicle/form.ts
@@ -13,6 +13,7 @@ import {
 } from './types';
 import { useMemo } from 'react';
 import { useVehiclesQ } from '@data/vehicle/queries';
+import { useParams } from 'react-router-dom';
 
 //
 
@@ -34,8 +35,14 @@ const vehicleBaseZ = z.object({
 });
 
 export function useVehicleZ() {
+  // Fetches the id parameter from the url, which would be the current vehicle.
+  const { id = '' } = useParams();
   const vehiclesQ = useVehiclesQ();
-  const regTags = vehiclesQ.data?.map((vehicle: any) => vehicle.regTag) || [];
+
+  // If regTags possibly being undefined ends up as a problem, just add '?? []' at the end.
+  const regTags = vehiclesQ.data
+    ?.filter((vehicle) => vehicle.id !== id)
+    .map((vehicle) => vehicle.regTag);
 
   return useMemo(
     () => {


### PR DESCRIPTION
The current regTag gets excluded from the the unqiue regTag validation. When editing a vehicle it wouldn't work as the unqiue regTag validation would get upset that the regTag of the vehicle that is being edited is already being used. The current regTag gets excluded based on the id parameter from the url, so if the reg is like the regTag from the current url it gets excluded.