### PR TITLE
fix(web): give key value to locales; removes warning

### DIFF
--- a/web/src/root/index.tsx
+++ b/web/src/root/index.tsx
@@ -95,6 +95,7 @@ function RouteHelmet({
           />
           {locales.map((locale) => (
             <link
+              key={locale}
               rel="alternative"
               href={`${import.meta.env.DOMAIN}/${locale}${route.path}`}
               hrefLang={locale}


### PR DESCRIPTION
Removes potential eventual issues with locale indices by specifying a unique key for every locale. Removes warning relating to this while running web service.