### PR TITLE
refactor(web): Simplify <DataForm.Provider /> side effects

### DIFF
--- a/web/src/components/DataForm/DataFormDatePicker.tsx
+++ b/web/src/components/DataForm/DataFormDatePicker.tsx
@@ -21,7 +21,7 @@ export const DatePicker = ({
   fromDate,
 }: DataFormDateProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const { isSkeleton, isDisabled, body, setBodyProp } = useDataForm();
+  const { isLoading, isDisabled, body, setBodyProp } = useDataForm();
 
   return (
     <Field label={label} dataKey={dataKey} description={description}>
@@ -36,7 +36,7 @@ export const DatePicker = ({
             )}
             icon={CalendarIcon}
             text={
-              isSkeleton
+              isLoading
                 ? ''
                 : body[dataKey]
                   ? format(body[dataKey], 'PPP')

--- a/web/src/components/DataForm/DataFormInput.tsx
+++ b/web/src/components/DataForm/DataFormInput.tsx
@@ -21,7 +21,7 @@ export const Input = ({
   description,
   disabled,
 }: InputProps) => {
-  const { body, setBodyProp, isDisabled, isSkeleton } = useDataForm();
+  const { body, setBodyProp, isDisabled } = useDataForm();
 
   const formIsDisabled = isDisabled || disabled;
 
@@ -34,7 +34,7 @@ export const Input = ({
         id={dataKey}
         disabled={formIsDisabled}
         placeholder={placeholder}
-        value={isSkeleton ? '' : (body[dataKey] ?? '')}
+        value={body[dataKey]}
         onChange={({ target: { value } }) => {
           if (body[dataKey] !== value) {
             setBodyProp(dataKey, type === 'number' ? Number(value) : value);

--- a/web/src/components/DataForm/DataFormSelect.tsx
+++ b/web/src/components/DataForm/DataFormSelect.tsx
@@ -27,7 +27,7 @@ export const Select = ({
   disabled,
   fat,
 }: SelectProps) => {
-  const { isSkeleton, body, setBodyProp, isDisabled } = useDataForm();
+  const { isLoading, body, setBodyProp, isDisabled } = useDataForm();
   const [open, setOpen] = useState(false);
 
   const isDisabledUnion = isDisabled || disabled;
@@ -109,7 +109,7 @@ export const Select = ({
             )}
           >
             {Icon && <Icon className="mr-2 h-4 w-4" />}
-            {isSkeleton
+            {isLoading
               ? ''
               : hasData
                 ? buttonLabel

--- a/web/src/components/DataForm/DataFormSwitch.tsx
+++ b/web/src/components/DataForm/DataFormSwitch.tsx
@@ -15,7 +15,7 @@ export const Switch = ({
   dataKey,
   description,
 }: DataFormSwitchProps) => {
-  const { body, setBodyProp, isDisabled, isSkeleton } = useDataForm();
+  const { body, setBodyProp, isDisabled, isLoading } = useDataForm();
 
   return (
     <Field label={label} dataKey={dataKey} description={description}>
@@ -27,7 +27,7 @@ export const Switch = ({
         <SwitchDumb
           checked={body[dataKey]}
           onCheckedChange={(val) => setBodyProp(dataKey, val)}
-          isSkeleton={isSkeleton}
+          isSkeleton={isLoading}
           disabled={isDisabled}
         />
         <span>

--- a/web/src/root/Portal/PortalForm.tsx
+++ b/web/src/root/Portal/PortalForm.tsx
@@ -40,7 +40,7 @@ export default function PortalForm({
   disableEdit,
 }: PortalFormProps) {
   const { id = '' } = useParams();
-  const { mode, body, submitError, isLoading, isSkeleton } = useDataForm();
+  const { mode, body, submitError, isLoading } = useDataForm();
   const { toast } = useToast();
   const navigate = useNavigate();
 
@@ -134,8 +134,7 @@ export default function PortalForm({
                   isSubmitting ||
                   !!submitError ||
                   !!disableEdit ||
-                  isLoading ||
-                  isSkeleton
+                  isLoading
                 }
                 onClick={handler}
                 variant={mode === Mode.READ ? 'outline' : 'default'}

--- a/web/src/utils.tsx
+++ b/web/src/utils.tsx
@@ -1,6 +1,7 @@
 import { AxiosInstance } from 'axios';
 import { ClassValue, clsx } from 'clsx';
 import localeCodes from 'locale-codes';
+import { FC } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
@@ -184,6 +185,19 @@ export const useAxiosCookieJar = (instance: AxiosInstance) => {
     instance.interceptors.request.eject(reqInterceptorId);
   };
 };
+
+/**
+ * This is a React higher-order-component. It is used to trigger destroy and
+ * remount of a component by having its `key` prop mapped to by a `toKey`
+ * function
+ *
+ * @param toKey This is the function that will set the value of the `key` props.
+ * @param Comp What ever component you wish to lobotomize.
+ */
+
+export const withLobotomizer =
+  <Props,>(toKey: (props: Props) => string, Comp: FC<Props>): FC<Props> =>
+  (props) => <Comp key={toKey(props)} {...props} />;
 
 //
 


### PR DESCRIPTION
By creating the withLobotomiser hoc we can let the provider start fresh when ever the mode changes. This heavyly simplifies the internal bussiness logic. We no longer need to try juggle the state and props according to mode changes. Just instanciate the compoent from scratch everytime.

Cool.