### PR TITLE
fix(web): Sorting on columns not working on admin pages

### DIFF
--- a/web/src/data/location/queries.ts
+++ b/web/src/data/location/queries.ts
@@ -9,7 +9,14 @@ import * as api from './api';
 //
 
 export const useLocationsQ = () =>
-  useQuery<Location[], StandardError>(api.createGetLocations());
+  useQuery<Location[], StandardError>({
+    ...api.createGetLocations(),
+    select: (locations) =>
+      locations?.map((location) => ({
+        ...location,
+        vehicleCount: location.vehicleIds?.length || 0,
+      })),
+  });
 
 export interface UseLocationQProps {
   id: string;

--- a/web/src/root/Portal/PortalAdminEmployees/useColumns.tsx
+++ b/web/src/root/Portal/PortalAdminEmployees/useColumns.tsx
@@ -12,7 +12,7 @@ export default function useColumns() {
     () =>
       [
         {
-          key: 'name',
+          key: 'firstName',
           name: 'Name',
           renderFn: ({ firstName, lastName }) => (
             <IconLabel label={`${firstName} ${lastName}`} />
@@ -20,7 +20,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'persidnr',
+          key: 'personalIdentityNumber',
           name: 'Pers. Identity No.',
           renderFn: ({ personalIdentityNumber }) => (
             <IconLabel label={personalIdentityNumber} />
@@ -28,7 +28,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'phonenr',
+          key: 'phoneNumber',
           name: 'Phone No.',
           renderFn: ({ phoneNumber }) => <IconLabel label={phoneNumber} />,
         },
@@ -40,7 +40,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'no',
+          key: 'employeeNumber',
           name: 'Empl. No.',
           renderFn: ({ employeeNumber }) => (
             <IconLabel label={employeeNumber} />
@@ -48,7 +48,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'createdat',
+          key: 'createdAt',
           name: 'Created at',
           renderFn: ({ createdAt }) => (
             <IconLabel label={format(new Date(createdAt), 'yyyy-MM-dd')} />
@@ -56,7 +56,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'updatedat',
+          key: 'updatedAt',
           name: 'Edited at',
           renderFn: ({ updatedAt }) => (
             <IconLabel label={format(new Date(updatedAt), 'yyyy-MM-dd')} />

--- a/web/src/root/Portal/PortalAdminLocations/useColumns.tsx
+++ b/web/src/root/Portal/PortalAdminLocations/useColumns.tsx
@@ -29,12 +29,12 @@ export default function useColumns() {
 
         {
           key: 'address',
-          address: 'Address',
+          name: 'Address',
           renderFn: ({ address }) => <IconLabel label={address} />,
         },
 
         {
-          key: 'vehicle-count',
+          key: 'vehicleCount',
           name: 'Vehicle count',
           renderFn: ({ vehicleIds }) => (
             <IconLabel label={vehicleIds.length.toString()} />
@@ -52,7 +52,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'createdat',
+          key: 'createdAt',
           name: 'Created at',
           renderFn: ({ createdAt }) => (
             <IconLabel label={format(new Date(createdAt), 'yyyy-MM-dd')} />
@@ -60,7 +60,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'updatedat',
+          key: 'updatedAt',
           name: 'Edited at',
           renderFn: ({ updatedAt }) => (
             <IconLabel label={format(new Date(updatedAt), 'yyyy-MM-dd')} />

--- a/web/src/root/Portal/PortalAdminUsers/useColumns.tsx
+++ b/web/src/root/Portal/PortalAdminUsers/useColumns.tsx
@@ -38,7 +38,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'createdat',
+          key: 'createdAt',
           name: 'Created at',
           renderFn: ({ createdAt }) => (
             <IconLabel label={format(new Date(createdAt), 'yyyy-MM-dd')} />
@@ -46,7 +46,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'updatedat',
+          key: 'updatedAt',
           name: 'Edited at',
           renderFn: ({ updatedAt }) => (
             <IconLabel label={format(new Date(updatedAt), 'yyyy-MM-dd')} />


### PR DESCRIPTION
Sorting now works on the admin pages columns using the correct keys in useColumns.