### PR TITLE
fix(web): filtering tickets also includes timestamps

### DIFF
--- a/web/src/root/Portal/PortalShopTickets/ShopTicketsFilters.tsx
+++ b/web/src/root/Portal/PortalShopTickets/ShopTicketsFilters.tsx
@@ -18,6 +18,7 @@ import {
   VehicleShortcutAction,
   VehicleShortcutLocationState,
 } from '../PortalShopInventory/ShopInventoryActions';
+import { matchDateWithoutTimestamp } from '@utils';
 
 export default function ShopTicketFilters() {
   const ticketsQ = useTicketsAggregatedQ();
@@ -62,11 +63,14 @@ export default function ShopTicketFilters() {
 
   const filterSearchMatchFn = (word: string, row: TicketAggregated) =>
     enums.matchFn(word, row) ||
-    DataTable.fuzzyMatchFn(
-      ['comment', 'startDate', 'endDate', 'repairDescription'],
-      word,
-      row,
-    ) ||
+    DataTable.fuzzyMatchFn(['comment', 'repairDescription'], word, row) ||
+    matchDateWithoutTimestamp(word, row.startDate) ||
+    matchDateWithoutTimestamp(word, row.endDate) ||
+    enumsMatchUtil({
+      enums: employeeEnumsQ.data,
+      isOf: row.employeeId,
+      includes: word,
+    }) ||
     enumsMatchUtil({
       enums: employeeEnumsQ.data,
       isOf: row.employeeId,

--- a/web/src/utils.tsx
+++ b/web/src/utils.tsx
@@ -195,3 +195,12 @@ export const formatDays = (dayCount?: number) =>
       : dayCount && dayCount > 1
         ? `${dayCount} days ago}`
         : undefined;
+
+export function matchDateWithoutTimestamp(
+  search: string,
+  dateStr?: string,
+): boolean {
+  if (!dateStr) return false;
+  const formattedDate = dateStr.split('T')[0];
+  return formattedDate.toLowerCase().includes(search.toLowerCase());
+}


### PR DESCRIPTION
adds a util now used in fuzzyMatchfn that removes the timestamp from start_date and end_date since that was included when searching in the tickets page.

bug#70