### PR TITLE
feat(api): Image upload endpoint and S3Service for file uploads

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -99,6 +99,16 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.5.0</version>
 		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-s3</artifactId>
+			<version>1.12.782</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tika</groupId>
+			<artifactId>tika-core</artifactId>
+			<version>2.9.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/main/src/main/java/se/hjulverkstan/Exceptions/FileContentMismatchException.java
+++ b/main/src/main/java/se/hjulverkstan/Exceptions/FileContentMismatchException.java
@@ -1,0 +1,9 @@
+package se.hjulverkstan.Exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class FileContentMismatchException extends ApiException{
+    public FileContentMismatchException(String message) {
+        super("file_content_mismatch", message, HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/main/src/main/java/se/hjulverkstan/Exceptions/FileEmptyException.java
+++ b/main/src/main/java/se/hjulverkstan/Exceptions/FileEmptyException.java
@@ -1,0 +1,9 @@
+package se.hjulverkstan.Exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class FileEmptyException extends ApiException {
+    public FileEmptyException(String message) {
+        super("file_empty_or_missing", message, HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/main/src/main/java/se/hjulverkstan/Exceptions/FileProcessingException.java
+++ b/main/src/main/java/se/hjulverkstan/Exceptions/FileProcessingException.java
@@ -1,0 +1,16 @@
+package se.hjulverkstan.Exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class FileProcessingException extends ApiException {
+    public FileProcessingException(String message, HttpStatus status) {
+        super("file_processing_error", message, status.value());
+    }
+
+    public FileProcessingException(String message) {
+        super("file_processing_error", message, HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+}
+
+
+

--- a/main/src/main/java/se/hjulverkstan/Exceptions/FileTooLargeException.java
+++ b/main/src/main/java/se/hjulverkstan/Exceptions/FileTooLargeException.java
@@ -1,0 +1,9 @@
+package se.hjulverkstan.Exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class FileTooLargeException extends ApiException{
+    public FileTooLargeException(String message) {
+        super("file_too_large", message, HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/main/src/main/java/se/hjulverkstan/Exceptions/S3UploadException.java
+++ b/main/src/main/java/se/hjulverkstan/Exceptions/S3UploadException.java
@@ -1,0 +1,10 @@
+package se.hjulverkstan.Exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class S3UploadException extends ApiException {
+    public S3UploadException(String message) {
+        super("s3_upload_error", message, HttpStatus.SERVICE_UNAVAILABLE.value());
+    }
+}
+

--- a/main/src/main/java/se/hjulverkstan/Exceptions/UnsupportedFileTypeException.java
+++ b/main/src/main/java/se/hjulverkstan/Exceptions/UnsupportedFileTypeException.java
@@ -1,0 +1,9 @@
+package se.hjulverkstan.Exceptions;
+
+import org.springframework.http.HttpStatus;
+
+public class UnsupportedFileTypeException extends ApiException {
+    public UnsupportedFileTypeException(String message) {
+        super("unsupported_image_file_type", message, HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/main/src/main/java/se/hjulverkstan/main/config/AwsS3Config.java
+++ b/main/src/main/java/se/hjulverkstan/main/config/AwsS3Config.java
@@ -1,0 +1,36 @@
+package se.hjulverkstan.main.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${AWS_S3_ACCESS_KEY}")
+    private String accessKey;
+
+    @Value("${AWS_S3_SECRET_KEY}")
+    private String secretKey;
+
+    @Value("${AWS_S3_REGION}")
+    private String region;
+
+    @Value("${AWS_S3_BUCKET_NAME}")
+    private String bucketName;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}
+

--- a/main/src/main/java/se/hjulverkstan/main/controller/ExceptionsController.java
+++ b/main/src/main/java/se/hjulverkstan/main/controller/ExceptionsController.java
@@ -15,10 +15,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-import se.hjulverkstan.Exceptions.ApiError;
-import se.hjulverkstan.Exceptions.ApiException;
-import se.hjulverkstan.Exceptions.TokenRefreshException;
+import se.hjulverkstan.Exceptions.*;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -109,4 +108,5 @@ public class ExceptionsController {
         return ResponseEntity.status(apiError.getStatus())
                 .body(apiError);
     }
+
 }

--- a/main/src/main/java/se/hjulverkstan/main/controller/ImageController.java
+++ b/main/src/main/java/se/hjulverkstan/main/controller/ImageController.java
@@ -1,0 +1,25 @@
+package se.hjulverkstan.main.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import se.hjulverkstan.main.dto.ImageUploadResponse;
+import se.hjulverkstan.main.service.S3Service;
+
+@RestController
+@RequestMapping("/v1/image")
+public class ImageController {
+
+    private final S3Service s3Service;
+
+    public ImageController(S3Service s3service) {
+        this.s3Service = s3service;
+    }
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ImageUploadResponse> uploadImage(@RequestParam("file") MultipartFile file) {
+        return new ResponseEntity<>(s3Service.uploadFile(file), HttpStatus.OK);
+    }
+}

--- a/main/src/main/java/se/hjulverkstan/main/dto/ImageUploadResponse.java
+++ b/main/src/main/java/se/hjulverkstan/main/dto/ImageUploadResponse.java
@@ -1,0 +1,14 @@
+package se.hjulverkstan.main.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImageUploadResponse {
+    private String imageURL;
+}
+
+

--- a/main/src/main/java/se/hjulverkstan/main/service/S3Service.java
+++ b/main/src/main/java/se/hjulverkstan/main/service/S3Service.java
@@ -1,0 +1,14 @@
+package se.hjulverkstan.main.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import se.hjulverkstan.main.dto.ImageUploadResponse;
+
+public interface S3Service {
+
+    ImageUploadResponse uploadFile(MultipartFile file);
+
+    void deleteFileByKey(String key);
+
+    String extractKeyFromURL(String URL);
+
+}

--- a/main/src/main/java/se/hjulverkstan/main/service/S3ServiceImpl.java
+++ b/main/src/main/java/se/hjulverkstan/main/service/S3ServiceImpl.java
@@ -1,0 +1,113 @@
+package se.hjulverkstan.main.service;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.apache.tika.Tika;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import se.hjulverkstan.Exceptions.*;
+import se.hjulverkstan.main.dto.ImageUploadResponse;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+public class S3ServiceImpl implements S3Service {
+
+    private final AmazonS3 amazonS3;
+    private static final List<String> ALLOWED_MIME_TYPES = Arrays.asList("image/jpeg", "image/png", "image/gif");
+    private static final Tika TIKA = new Tika();
+
+
+    @Value("${AWS_S3_BUCKET_NAME}")
+    private String bucketName;
+
+    public S3ServiceImpl(AmazonS3 amazonS3) {
+        this.amazonS3 = amazonS3;
+    }
+
+    /**
+     * Uploads a file to S3 and returns a public URL for the uploaded image.
+     *
+     * @param file the image file to upload
+     * @return an ImageUploadResponse containing the public URL
+     */
+    @Override
+    public ImageUploadResponse uploadFile(MultipartFile file) {
+        validateFile(file);
+
+        String uniqueFileName = generateUniqueFileName(file);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            PutObjectRequest putRequest = new PutObjectRequest(bucketName, uniqueFileName, inputStream, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(putRequest);
+
+            String publicUrl = amazonS3.getUrl(bucketName, uniqueFileName).toString();
+            return new ImageUploadResponse(publicUrl);
+        } catch (IOException e) {
+            throw new FileProcessingException("Error processing file: " + e.getMessage());
+        } catch (SdkClientException e) {
+            throw new S3UploadException("Failed to upload file to S3: " + e.getMessage());
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new FileEmptyException("File is empty or missing");
+        }
+
+        long maxFileSize = 5 * 1024 * 1024; // 5 MB
+        if (file.getSize() > maxFileSize) {
+            throw new FileTooLargeException("File size exceeds the maximum allowed limit (5 MB)");
+        }
+
+        String fileMimeType = file.getContentType();
+        if (fileMimeType == null || !ALLOWED_MIME_TYPES.contains(fileMimeType)) {
+            throw new UnsupportedFileTypeException("Unsupported file type: " + fileMimeType);
+        }
+
+        try (InputStream is = new BufferedInputStream(file.getInputStream())) {
+            String detectedType = TIKA.detect(is);
+            if (!ALLOWED_MIME_TYPES.contains(detectedType)) {
+                throw new FileContentMismatchException("File content does not match allowed types. Detected: " + detectedType);
+            }
+        } catch (IOException e) {
+            throw new FileProcessingException("Failed to read file for validation: " + e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private String generateUniqueFileName(MultipartFile file) {
+        String originalFilename = file.getOriginalFilename();
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+        return UUID.randomUUID().toString() + extension;
+    }
+
+    @Override
+    public void deleteFileByKey(String key) {
+
+    }
+
+    @Override
+    public String extractKeyFromURL(String URL) {
+        return "";
+    }
+}


### PR DESCRIPTION
Introduce an image upload endpoint that accepts multipart form-data and calls the S3Service to upload files to Amazon S3. Add AwsS3Config to create an AmazonS3 bean using environment variables. Integrate file validation in S3ServiceImpl to check for file presence, maximum size, allowed MIME types, and verify the actual file content using Apache Tika. Also introduce custom exceptions for robust error handling.