### PR TITLE
feat(web): add item warnings for vehicles and tickets

### DIFF
--- a/web/src/components/WarningBadge.tsx
+++ b/web/src/components/WarningBadge.tsx
@@ -1,0 +1,40 @@
+import BadgeGroup from '@components/BadgeGroup';
+import { find as warningFind } from '@data/warning/enums';
+import { BadgeProps } from '@components/shadcn/Badge';
+interface WarningBadgeProps {
+  id: string;
+  warnings: string[];
+  variant: BadgeProps['variant'];
+}
+
+export default function WarningBadge({
+  id,
+  warnings,
+  variant,
+}: WarningBadgeProps) {
+  const tooltip = warnings.length ? (
+    <div>
+      {warnings.map((warning, i) => (
+        <span key={i}>
+          {warningFind(warning).tooltip}
+          {i < warnings.length - 1 && <br />}
+        </span>
+      ))}
+    </div>
+  ) : undefined;
+
+  const icon = warnings.length ? warningFind(warnings[0]).icon : undefined;
+
+  return (
+    <BadgeGroup
+      badges={[
+        {
+          icon,
+          label: `#${id}`,
+          variant,
+          tooltip,
+        },
+      ]}
+    />
+  );
+}

--- a/web/src/data/ticket/queries.ts
+++ b/web/src/data/ticket/queries.ts
@@ -8,6 +8,7 @@ import { StandardError } from '../api';
 import * as api from './api';
 import * as enums from './enums';
 import { Ticket, TicketAggregated, TicketStatus } from './types';
+import { Warning } from '@data/warning/types';
 import { differenceInDays } from 'date-fns';
 
 //
@@ -41,6 +42,19 @@ export const useTicketsAggregatedQ = () =>
           ? differenceInDays(new Date(), new Date(ticket.statusUpdatedAt))
           : undefined;
 
+        const warnings: Warning[] = [
+          ...(ticket.startDate &&
+          new Date(ticket.startDate) < new Date() &&
+          ticket.ticketStatus === 'READY'
+            ? [Warning.DUE_PICKUP]
+            : []),
+          ...(ticket.endDate &&
+          new Date(ticket.endDate) < new Date() &&
+          ticket.ticketStatus === 'IN_PROGRESS'
+            ? [Warning.DUE_RETURN]
+            : []),
+        ];
+
         return {
           ...ticket,
           daysLeft,
@@ -52,6 +66,7 @@ export const useTicketsAggregatedQ = () =>
                   .locationId,
             ),
           ),
+          warnings,
         };
       }),
     [useTicketsQ(), useVehiclesQ()],

--- a/web/src/data/ticket/types.ts
+++ b/web/src/data/ticket/types.ts
@@ -1,3 +1,4 @@
+import { Warning } from '@data/warning/types';
 export enum TicketType {
   RENT = 'RENT',
   REPAIR = 'REPAIR',
@@ -38,6 +39,7 @@ export interface TicketAggregated extends Ticket {
   locationIds: string[];
   daysLeft?: number;
   daysSinceUpdate?: number;
+  warnings?: Warning[];
 }
 
 // Used to know which ticket status are available on a certain type of ticket

--- a/web/src/data/vehicle/queries.ts
+++ b/web/src/data/vehicle/queries.ts
@@ -6,6 +6,7 @@ import * as api from './api';
 import * as enums from './enums';
 import * as U from '@utils';
 import { Vehicle, VehicleType, VehicleAggregated } from './types';
+import { Warning } from '@data/warning/types';
 import { useTicketsQ } from '@data/ticket/queries';
 import { useAggregatedQueries } from '@hooks/useAggregatedQueries';
 import { TicketStatus } from '@data/ticket/types';
@@ -36,7 +37,10 @@ export const useVehiclesAggregatedQ = () =>
         const vehicleTickets = tickets.filter((ticket) =>
           vehicle.ticketIds.includes(ticket.id),
         );
-
+        const warnings: Warning[] =
+          vehicle.isCustomerOwned && vehicleTickets.length === 0
+            ? [Warning.ORPHAN]
+            : [];
         return {
           ...vehicle,
           ticketTypes: U.uniq(
@@ -47,6 +51,7 @@ export const useVehiclesAggregatedQ = () =>
               .map((ticket) => ticket.ticketStatus)
               .filter((status): status is TicketStatus => status !== undefined),
           ),
+          warnings,
         };
       }),
     [useVehiclesQ(), useTicketsQ()],

--- a/web/src/data/vehicle/types.ts
+++ b/web/src/data/vehicle/types.ts
@@ -1,4 +1,5 @@
 import { TicketStatus, TicketType } from '@data/ticket/types';
+import { Warning } from '@data/warning/types';
 
 export enum VehicleType {
   BIKE = 'BIKE',
@@ -90,4 +91,5 @@ export interface Vehicle {
 export interface VehicleAggregated extends Vehicle {
   ticketTypes: TicketType[];
   ticketStatuses: TicketStatus[];
+  warnings?: Warning[];
 }

--- a/web/src/data/warning/enums.ts
+++ b/web/src/data/warning/enums.ts
@@ -1,0 +1,34 @@
+import { Warning } from './types';
+import { AlertTriangle } from 'lucide-react';
+import { createFindFn, createMatchFn } from '../enums';
+
+export const warningEnums = [
+  {
+    dataKey: 'warning',
+    value: Warning.DUE_PICKUP,
+    label: 'Due pickup',
+    tooltip: 'Bike ready, waiting for pickup',
+    icon: AlertTriangle,
+    variant: 'destructive' as 'destructive',
+  },
+  {
+    dataKey: 'warning',
+    value: Warning.DUE_RETURN,
+    label: 'Due return',
+    tooltip: 'Bike still out past return date.',
+    icon: AlertTriangle,
+    variant: 'destructive' as 'destructive',
+  },
+  {
+    dataKey: 'warning',
+    value: Warning.ORPHAN,
+    label: 'Orphan',
+    tooltip: 'Bike orphaned: missing ticket.',
+    icon: AlertTriangle,
+    variant: 'destructive' as 'destructive',
+  },
+];
+
+export const all = warningEnums;
+export const find = createFindFn(all);
+export const matchFn = createMatchFn(all);

--- a/web/src/data/warning/types.ts
+++ b/web/src/data/warning/types.ts
@@ -1,0 +1,5 @@
+export enum Warning {
+  ORPHAN = 'ORPHAN',
+  DUE_PICKUP = 'DUE_PICKUP',
+  DUE_RETURN = 'DUE_RETURN',
+}

--- a/web/src/root/Portal/PortalShopInventory/useColumns.tsx
+++ b/web/src/root/Portal/PortalShopInventory/useColumns.tsx
@@ -8,6 +8,7 @@ import { useMemo } from 'react';
 import { useLocationsAsEnumsQ } from '@data/location/queries';
 import { TicketBadges } from '../PortalShopTickets/useColumns';
 import { format } from 'date-fns';
+import WarningBadge from '@components/WarningBadge';
 
 //
 
@@ -20,17 +21,32 @@ export default function useColumns() {
         {
           key: 'regTag',
           name: '#',
-          renderFn: ({ regTag, id, isCustomerOwned }, { selected }) => (
-            <BadgeGroup
-              badges={[
-                {
-                  ...enums.find(isCustomerOwned),
-                  ...(selected ? { variant: 'contrast' } : {}),
-                  label: isCustomerOwned ? `#${id}` : regTag,
-                },
-              ]}
-            />
-          ),
+          renderFn: (
+            { regTag, id, isCustomerOwned, warnings = [] },
+            { selected },
+          ) => {
+            const baseBadge = enums.find(isCustomerOwned);
+
+            const variant = selected
+              ? 'contrast'
+              : warnings.length
+                ? 'destructive'
+                : 'outline';
+
+            return warnings.length ? (
+              <WarningBadge id={id} warnings={warnings} variant={variant} />
+            ) : (
+              <BadgeGroup
+                badges={[
+                  {
+                    icon: baseBadge.icon,
+                    label: isCustomerOwned ? `#${id}` : regTag,
+                    variant,
+                  },
+                ]}
+              />
+            );
+          },
         },
 
         {

--- a/web/src/root/Portal/PortalShopTickets/useColumns.tsx
+++ b/web/src/root/Portal/PortalShopTickets/useColumns.tsx
@@ -8,15 +8,12 @@ import { TicketAggregated, TicketStatus } from '@data/ticket/types';
 import { useVehiclesAsEnumsQ } from '@data/vehicle/queries';
 import { useTicketsAsEnumsQ, useTicketsQ } from '@data/ticket/queries';
 import * as U from '@utils';
-
 import BadgeGroup from '@components/BadgeGroup';
 import * as DataTable from '@components/DataTable';
 import IconLabel from '@components/IconLabel';
-import { Badge } from '@components/shadcn/Badge';
 import { format } from 'date-fns';
 import usePortalSlugs from '@hooks/useSlugs';
-
-//
+import WarningBadge from '@components/WarningBadge';
 
 export function TicketBadges({ ticketIds }: { ticketIds: string[] }) {
   const { coreUrl } = usePortalSlugs();
@@ -89,9 +86,26 @@ export default function useColumns() {
         {
           key: 'id',
           name: '#',
-          renderFn: ({ id }, { selected }) => (
-            <Badge variant={selected ? 'contrast' : 'outline'}>#{id}</Badge>
-          ),
+          renderFn: ({ id, warnings = [] }, { selected }) => {
+            const variant = selected
+              ? 'contrast'
+              : warnings.length
+                ? 'destructive'
+                : 'outline';
+
+            return warnings.length ? (
+              <WarningBadge id={id} warnings={warnings} variant={variant} />
+            ) : (
+              <BadgeGroup
+                badges={[
+                  {
+                    label: `#${id}`,
+                    variant,
+                  },
+                ]}
+              />
+            );
+          },
         },
 
         {


### PR DESCRIPTION
Implement warnings that display icons and tooltips before IDs. Extend aggregated types with a warnings array and integrate a warning module (DUE_PICKUP, DUE_RETURN, ORPHAN). Extract shared logic into a helper.