### PR TITLE
fix(web): Rental ticket available on Create Ticket even though it shouldnt be

### DIFF
--- a/main/src/main/java/se/hjulverkstan/main/service/TicketServiceImpl.java
+++ b/main/src/main/java/se/hjulverkstan/main/service/TicketServiceImpl.java
@@ -106,11 +106,15 @@ public class TicketServiceImpl implements TicketService {
             if (!vehicle.getTickets().contains(selectedTicket)) vehicle.getTickets().add(selectedTicket);
         });
 
-        if (selectedTicket instanceof TicketRent) {
+        if (selectedTicket instanceof TicketRent || selectedTicket instanceof TicketDonate) {
             if(vehicles.stream().anyMatch(Vehicle::isCustomerOwned)){
-                throw new UnsupportedTicketVehiclesException("Customer Owned Vehicles cannot be selected for Rental Tickets!");
+                throw new UnsupportedTicketVehiclesException("Customer Owned Vehicles cannot be selected for Rental or Donate Tickets!");
             }
             vehicleRepository.saveAll(vehicles);
+        }
+
+        if(vehicles.stream().anyMatch(Vehicle::isCustomerOwned) && vehicles.stream().anyMatch(v ->!v.isCustomerOwned())){
+            throw new UnsupportedTicketVehiclesException("Cannot select both Customer Owned and Non Customer Owned Vehicles!");
         }
 
 
@@ -173,13 +177,16 @@ public class TicketServiceImpl implements TicketService {
             if (!vehicle.getTickets().contains(ticket)) vehicle.getTickets().add(ticket);
         });
 
-        if (ticket instanceof TicketRent) {
+        if (ticket instanceof TicketRent || ticket instanceof TicketDonate) {
             if(vehicles.stream().anyMatch(Vehicle::isCustomerOwned)){
-                throw new UnsupportedTicketVehiclesException("Customer Owned Vehicles cannot be selected for Rental Tickets!");
+                throw new UnsupportedTicketVehiclesException("Customer Owned Vehicles cannot be selected for Rental or Donate Tickets!");
             }
             vehicleRepository.saveAll(vehicles);
         }
 
+        if(vehicles.stream().anyMatch(Vehicle::isCustomerOwned) && vehicles.stream().anyMatch(v ->!v.isCustomerOwned())){
+            throw new UnsupportedTicketVehiclesException("Cannot select both Customer Owned and Non Customer Owned Vehicles!");
+        }
 
         Employee employee = getTicketEmployee(newTicket.getEmployeeId());
         employee.getTickets().add(ticket);

--- a/web/src/data/ticket/form.ts
+++ b/web/src/data/ticket/form.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { isReq } from '../form';
+import { isReq, reqString } from '../form';
 import { Ticket, TicketType } from '@data/ticket/types';
 
 export const initTicket = {
@@ -9,14 +9,18 @@ export const initTicket = {
 const ticketBaseZ = z.object({
   ticketType: z.nativeEnum(TicketType, isReq('Ticket type')),
   startDate: z.string(isReq('Start date')),
-  vehicleIds: z.array(z.string(isReq('Vehicle ids'))),
+  vehicleIds: z
+    .array(z.string(isReq('Vehicle ids')))
+    .min(1, 'At least one vehicle is required'),
   employeeId: z.string(isReq('Employee id')),
   customerId: z.string(isReq('Customer id')),
 });
 
 const ticketBaseZSecond = z.object({
   ticketType: z.nativeEnum(TicketType, isReq('Ticket type')),
-  vehicleIds: z.array(z.string(isReq('Vehicle ids'))),
+  vehicleIds: z
+    .array(z.string(isReq('Vehicle ids')))
+    .min(1, 'At least one vehicle is required'),
   employeeId: z.string(isReq('Employee id')),
   customerId: z.string(isReq('Customer id')),
 });
@@ -30,7 +34,7 @@ export const ticketZ = z.discriminatedUnion(
     }),
     ticketBaseZ.extend({
       ticketType: z.literal(TicketType.REPAIR),
-      repairDescription: z.string(isReq('Repair description')),
+      repairDescription: reqString('Repair description'),
       endDate: z.string(isReq('End date')),
     }),
     ticketBaseZSecond.extend({

--- a/web/src/data/vehicle/queries.ts
+++ b/web/src/data/vehicle/queries.ts
@@ -57,10 +57,15 @@ export const useVehiclesAggregatedQ = () =>
     [useVehiclesQ(), useTicketsQ()],
   );
 
+export interface UseVehiclesAsEnumsQProps {
+  dataKey?: string;
+  filterCustomerOwned?: boolean;
+}
+
 export const useVehiclesAsEnumsQ = ({
   dataKey = 'vehicleId',
   filterCustomerOwned,
-}: { dataKey?: string; filterCustomerOwned?: boolean } = {}) =>
+}: UseVehiclesAsEnumsQProps = {}) =>
   useQuery<Vehicle[], StandardError, EnumAttributes[]>({
     ...api.createGetVehicles(),
     select: (vehicles) =>

--- a/web/src/data/vehicle/types.ts
+++ b/web/src/data/vehicle/types.ts
@@ -85,7 +85,7 @@ export interface Vehicle {
   createdBy: number | null;
   updatedBy: number | null;
   //
-  isCustomerOwned?: string;
+  isCustomerOwned?: boolean;
 }
 
 export interface VehicleAggregated extends Vehicle {


### PR DESCRIPTION
 #184 Fixed so that when using the action menu from Inventory and selecting Create Ticket, when you select a customerOwned Vehicle TicketType RENT no longer appears in the list of tickets on the Ticket Page, but still do for Hjulverkstan Owned vehicles.
 Same with Donate Tickets.  
 And also it's mandatory to select a vehicle when creating tickets.