### PR TITLE
fix(web): Signup on permitAll

### DIFF
--- a/main/src/main/java/se/hjulverkstan/main/config/WebSecurityConfig.java
+++ b/main/src/main/java/se/hjulverkstan/main/config/WebSecurityConfig.java
@@ -74,7 +74,6 @@ public class WebSecurityConfig {
                     auth.requestMatchers("/v1/auth/login",
                                     "/v1/auth/refreshtoken",
                                     "/v1/auth/signout/*",
-                                    "/v1/user/signup",
                                     "v1/public/**",
                                     "/api/v3/api-docs/**",
                                     "/api/swagger-ui/**",


### PR DESCRIPTION
 In WebSecurityConfig signUp endpoint was in the permitAll requestMatchers, with this removed the crash in Users when refreshtoken expired no longer occurs.
 
 [#165](https://github.com/Hjulverkstan/hjulverkstan/issues/165)