### PR TITLE
feat(web): Success toasts on mutation

### DIFF
--- a/web/src/components/shadcn/Toast.tsx
+++ b/web/src/components/shadcn/Toast.tsx
@@ -15,7 +15,7 @@ export const Viewport = React.forwardRef<
     ref={ref}
     className={cn(
       `fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse space-y-2
-      p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]`,
+      p-4 sm:bottom-0 sm:left-0 sm:top-auto sm:flex-col md:max-w-[420px]`,
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ Viewport.displayName = ToastPrimitives.Viewport.displayName;
 export const toastVariants = cva(
   `data-[state=open]:animate-in data-[state=closed]:animate-out
   data-[swipe=end]:animate-out data-[state=closed]:fade-out-80
-  data-[state=closed]:slide-out-to-right-full
+  data-[state=closed]:slide-out-to-left-full
   data-[state=open]:slide-in-from-top-full
   data-[state=open]:sm:slide-in-from-bottom-full group pointer-events-auto
   relative flex w-full items-center justify-between space-x-2 overflow-hidden

--- a/web/src/root/Portal/PortalForm.tsx
+++ b/web/src/root/Portal/PortalForm.tsx
@@ -9,15 +9,15 @@ import { Button, IconButton } from '@components/shadcn/Button';
 import { useToast } from '@components/shadcn/use-toast';
 import Error from '@components/Error';
 
-import { createErrorToast } from './toast';
+import { createErrorToast, createSuccessToast } from './toast';
 
 export interface PortalFormProps {
-  /* Optionaly tranform the body on submit before passed to mutate function */
+  /* Optionally tranform the body on submit before passed to mutate function */
   transformBodyOnSubmit?: (input: any) => any;
   isSubmitting: boolean;
-  /* muateAsync from useMutation() */
+  /* mutateAsync from useMutation() */
   createMutation: (body: any) => Promise<any>;
-  /* muateAsync from useMutation() */
+  /* mutateAsync from useMutation() */
   saveMutation: (body: any) => Promise<any>;
   error?: ErrorRes | null;
   dataLabel: string;
@@ -47,7 +47,16 @@ export default function PortalForm({
   const onCreate = () => {
     if (!submitError) {
       createMutation(transformBodyOnSubmit(body))
-        .then((res: any) => navigate('../' + res.id))
+        .then((res: any) => {
+          navigate('../' + res.id);
+          toast(
+            createSuccessToast({
+              verbLabel: 'create',
+              dataLabel: `${dataLabel}`,
+              id,
+            }),
+          );
+        })
         .catch((err: any) => {
           console.error(err);
           toast(
@@ -63,7 +72,16 @@ export default function PortalForm({
   const onSave = () => {
     if (!submitError) {
       saveMutation(transformBodyOnSubmit(body))
-        .then((res: any) => navigate('../' + res.id))
+        .then((res: any) => {
+          navigate('../' + res.id);
+          toast(
+            createSuccessToast({
+              verbLabel: 'save',
+              dataLabel: `${dataLabel}`,
+              id,
+            }),
+          );
+        })
         .catch((err: any) => {
           console.error(err);
           toast(


### PR DESCRIPTION
Toasts popup on successful mutations.
Toasts now popup on the left side of the screen.
Toasts now dissappear to the left of the screen.

Solves issue #202