### PR TITLE
feat(api): S3 Orphan File Cleaner

### DIFF
--- a/api/src/main/java/se/hjulverkstan/main/MainApplication.java
+++ b/api/src/main/java/se/hjulverkstan/main/MainApplication.java
@@ -3,8 +3,10 @@ package se.hjulverkstan.main;
 import org.springframework.boot.SpringApplication;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import se.hjulverkstan.main.config.DotenvApplicationContextInitializer;
 
+@EnableScheduling
 @SpringBootApplication
 public class MainApplication {
 	public static void main(String[] args) {

--- a/api/src/main/java/se/hjulverkstan/main/jobs/S3OrphanFileCleanup.java
+++ b/api/src/main/java/se/hjulverkstan/main/jobs/S3OrphanFileCleanup.java
@@ -1,0 +1,63 @@
+package se.hjulverkstan.main.jobs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import se.hjulverkstan.main.repository.ImageRepositoryImpl;
+import se.hjulverkstan.main.service.S3ServiceImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class S3OrphanFileCleanup {
+    private static final Logger logger = LoggerFactory.getLogger(S3OrphanFileCleanup.class);
+
+    private static final int BATCH_SIZE = 100;
+
+    private final ImageRepositoryImpl imageRepositoryImpl;
+    private final S3ServiceImpl s3ServiceImpl;
+
+    public S3OrphanFileCleanup(ImageRepositoryImpl imageRepositoryImpl, S3ServiceImpl s3Service) {
+        this.imageRepositoryImpl = imageRepositoryImpl;
+        this.s3ServiceImpl = s3Service;
+    }
+
+    @Scheduled(cron = "${cleanup.s3-orphan-files.cron}")
+    public void runCleanup() {
+        List<String> usedUrls = imageRepositoryImpl.getAllUsedS3URLs();
+        List<String> allImageKeys = s3ServiceImpl.getAllImageKeys();
+
+        Set<String> usedKeys = usedUrls.stream()
+                        .map(s3ServiceImpl::extractKeyFromURL)
+                        .collect(Collectors.toSet());
+
+        List<String> orphanKeys = allImageKeys.stream()
+                        .filter(key -> !usedKeys.contains(key))
+                        .toList();
+
+        logger.info("Found {} orphan files to delete", orphanKeys.size());
+
+        deleteInBatches(orphanKeys);
+    }
+
+    private void deleteInBatches(List<String> keys) {
+        List<List<String>> batches = new ArrayList<>();
+
+        for (int i = 0; i < keys.size(); i += BATCH_SIZE) {
+            batches.add(keys.subList(i, Math.min(keys.size(), i + BATCH_SIZE)));
+        }
+
+        batches.parallelStream().forEach(batch -> {
+            try {
+                s3ServiceImpl.deleteFilesByKeys(batch);
+                logger.info("Deleted batch of orphan files: {}", batch);
+            } catch (Exception e) {
+                logger.error("Error deleting batch of orphan files: {}. Cause: {}", batch, e.getMessage(), e);
+            }
+        });
+    }
+}

--- a/api/src/main/java/se/hjulverkstan/main/service/S3Service.java
+++ b/api/src/main/java/se/hjulverkstan/main/service/S3Service.java
@@ -3,11 +3,14 @@ package se.hjulverkstan.main.service;
 import org.springframework.web.multipart.MultipartFile;
 import se.hjulverkstan.main.dto.ImageUploadResponse;
 
-public interface S3Service {
+import java.util.List;
 
+public interface S3Service {
     ImageUploadResponse uploadFile(MultipartFile file);
 
     String extractKeyFromURL(String url);
     void deleteFileByKey(String key);
+    void deleteFilesByKeys(List<String> keys);
 
+    List<String> getAllImageKeys();
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -25,6 +25,15 @@ spring.jackson.default-property-inclusion=non_null
 springdoc.api-docs.path=/api/v3/api-docs
 springdoc.swagger-ui.path=/api/swagger-ui.html
 
+# Cron Expression for a Scheduled S3 Orphan File Cleanup
+cleanup.s3-orphan-files.cron=0 0 3 * * TUE,SAT
+
+# Test setup for cron
+# Every minute:                         0 * * * * *             Good for testing.
+# At 02:00 every day:                   0 0 2 * * *             General recommended timing.
+# At 03:00 every Sunday:                0 0 3 * * 0             Low-activity systems.
+# At 03:00 every Tuesday, Saturday:     0 0 3 * * TUE,SAT       Slightly less low-activity systems
+
 # App Properties
 saveChild.app.jwtSecret= ======================Save=Child===========================
 # 15 minutes


### PR DESCRIPTION
New class is created to clean (delete) orphaned file (image) keys from the S3 bucket. Orphaned files are those that are not referenced by any objects.

Resolves: #147