### PR TITLE
fix(api): Unable to create JAR file on windows

### DIFF
--- a/main/src/main/java/se/hjulverkstan/main/config/DotenvApplicationContextInitializer.java
+++ b/main/src/main/java/se/hjulverkstan/main/config/DotenvApplicationContextInitializer.java
@@ -27,7 +27,9 @@ public class DotenvApplicationContextInitializer implements ApplicationContextIn
      */
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
-        String projectRootPath = Paths.get("").toAbsolutePath().toString().replace("/main", "");
+        String projectRootPath = Paths.get("").toAbsolutePath().toString()
+                .replace("\\main", "")
+                .replace("/main", "");
 
         Dotenv dotenv = Dotenv.configure()
                 .directory(projectRootPath)


### PR DESCRIPTION
 DotenvApplicationContextInitializer class would get errors on its projectRootPath when running mvn package (for getting JAR file) since the replacing of "/main", to empty string only works on Unix-based environments, but adding "\\main" makes it works on windows environments aswell.