### PR TITLE
feat(api): Filtering on public vehicle endpoint

### DIFF
--- a/api/src/main/java/se/hjulverkstan/main/controller/PublicController.java
+++ b/api/src/main/java/se/hjulverkstan/main/controller/PublicController.java
@@ -2,10 +2,7 @@ package se.hjulverkstan.main.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import se.hjulverkstan.main.dto.responses.GetAllVehicleDto;
 import se.hjulverkstan.main.dto.vehicles.VehicleDto;
 import se.hjulverkstan.main.service.VehicleService;
@@ -20,12 +17,16 @@ public class PublicController {
     }
 
     @GetMapping("/vehicle")
-    public ResponseEntity<GetAllVehicleDto> getAllVehicles() {
-        return new ResponseEntity<>(vehicleService.getAllVehicles(), HttpStatus.OK);
+    public ResponseEntity<GetAllVehicleDto> getAllPublicVehicles(@RequestParam(required = false) Long locationId) {
+        if (locationId != null) {
+            return new ResponseEntity<>(vehicleService.getAllPublicVehiclesByLocationId(locationId), HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>(vehicleService.getAllPublicVehicles(), HttpStatus.OK);
+        }
     }
 
     @GetMapping("/vehicle/{id}")
-    public ResponseEntity<VehicleDto> getVehicleById(@PathVariable Long id) {
-        return new ResponseEntity<>(vehicleService.getVehicleById(id), HttpStatus.OK);
+    public ResponseEntity<VehicleDto> getPublicVehicleById(@PathVariable Long id) {
+        return new ResponseEntity<>(vehicleService.getPublicVehicleById(id), HttpStatus.OK);
     }
 }

--- a/api/src/main/java/se/hjulverkstan/main/repository/PublicRepository.java
+++ b/api/src/main/java/se/hjulverkstan/main/repository/PublicRepository.java
@@ -1,0 +1,10 @@
+package se.hjulverkstan.main.repository;
+import se.hjulverkstan.main.model.Vehicle;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PublicRepository {
+    List<Vehicle> findPublicAvailableVehicles(Long locationId);
+    Optional<Vehicle> findById(Long id);
+}

--- a/api/src/main/java/se/hjulverkstan/main/repository/PublicRepositoryImpl.java
+++ b/api/src/main/java/se/hjulverkstan/main/repository/PublicRepositoryImpl.java
@@ -1,0 +1,77 @@
+package se.hjulverkstan.main.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import se.hjulverkstan.main.model.TicketStatus;
+import se.hjulverkstan.main.model.TicketType;
+import se.hjulverkstan.main.model.Vehicle;
+import se.hjulverkstan.main.model.VehicleStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@Transactional
+
+public class PublicRepositoryImpl implements PublicRepository {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Value("${rentalTimeMarginInDays}")
+    private int rentalTimeMarginInDays;
+
+    private List<Vehicle> findPublicAvailableVehiclesWithinMargin(Long vehicleId, Long locationId) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime margin = now.plusDays(rentalTimeMarginInDays);
+
+        String baseQuery = """
+            SELECT v FROM Vehicle v
+            WHERE v.isCustomerOwned = false
+              AND v.vehicleStatus = :status
+              AND NOT EXISTS (
+                  SELECT t FROM Ticket t
+                  JOIN t.vehicles tv
+                  WHERE tv = v
+                    AND t.ticketType = :rentType
+                    AND t.ticketStatus != :closed
+                    AND t.startDate BETWEEN :now AND :margin
+              )
+        """;
+
+        if (vehicleId != null) {
+            baseQuery += " AND v.id = :vehicleId";
+        }
+        if (locationId != null) {
+            baseQuery += " AND v.location.id = :locationId";
+        }
+
+        var query = entityManager.createQuery(baseQuery, Vehicle.class)
+                .setParameter("status", VehicleStatus.AVAILABLE)
+                .setParameter("rentType", TicketType.RENT)
+                .setParameter("closed", TicketStatus.CLOSED)
+                .setParameter("now", now)
+                .setParameter("margin", margin);
+
+        if (vehicleId != null) {
+            query.setParameter("vehicleId", vehicleId);
+        }
+        if (locationId != null) {
+            query.setParameter("locationId", locationId);
+        }
+
+        return query.getResultList();
+    }
+     @Override
+     public List<Vehicle> findPublicAvailableVehicles(Long locationId) {
+         return findPublicAvailableVehiclesWithinMargin(null, locationId);
+     }
+
+    @Override
+    public Optional<Vehicle> findById(Long id) {
+        return findPublicAvailableVehiclesWithinMargin(id, null).stream().findFirst();
+    }
+}

--- a/api/src/main/java/se/hjulverkstan/main/service/VehicleService.java
+++ b/api/src/main/java/se/hjulverkstan/main/service/VehicleService.java
@@ -8,11 +8,12 @@ import se.hjulverkstan.main.dto.vehicles.VehicleDto;
 
 public interface VehicleService {
     VehicleDto createVehicle(NewVehicleDto newVehicle);
-
+    GetAllVehicleDto getAllPublicVehicles();
     GetAllVehicleDto getAllVehicles();
+    GetAllVehicleDto getAllPublicVehiclesByLocationId(Long id);
 
     VehicleDto deleteVehicle(Long id);
-
+    VehicleDto getPublicVehicleById(Long id);
     VehicleDto getVehicleById(Long id);
 
     EditVehicleDto editVehicle(Long id, EditVehicleDto Vehicle);

--- a/api/src/main/java/se/hjulverkstan/main/service/VehicleServiceImpl.java
+++ b/api/src/main/java/se/hjulverkstan/main/service/VehicleServiceImpl.java
@@ -12,24 +12,28 @@ import se.hjulverkstan.main.dto.vehicles.*;
 import se.hjulverkstan.main.dto.responses.*;
 import se.hjulverkstan.main.model.*;
 import se.hjulverkstan.main.repository.LocationRepository;
+import se.hjulverkstan.main.repository.PublicRepository;
 import se.hjulverkstan.main.repository.VehicleRepository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
 public class VehicleServiceImpl implements VehicleService {
     private final VehicleRepository vehicleRepository;
     private final LocationRepository locationRepository;
+    private final PublicRepository publicRepository;
     public static String ELEMENT_VEHICLE = "Vehicle";
     public static String ELEMENT_LOCATION = "Location";
 
     @Autowired
-    public VehicleServiceImpl(VehicleRepository vehicleRepository, LocationRepository locationRepository) {
+    public VehicleServiceImpl(VehicleRepository vehicleRepository, LocationRepository locationRepository, PublicRepository publicRepository) {
         this.vehicleRepository = vehicleRepository;
         this.locationRepository = locationRepository;
+        this.publicRepository = publicRepository;
     }
 
     @Override
@@ -72,16 +76,41 @@ public class VehicleServiceImpl implements VehicleService {
         return convertToDto(vehicle);
     }
 
+
+    @Override
+    public GetAllVehicleDto getAllPublicVehicles() {
+        List<Vehicle> vehicles = publicRepository.findPublicAvailableVehicles(null);
+        List<VehicleDto> vehicleDtos = vehicles.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+
+        return new GetAllVehicleDto(vehicleDtos);
+    }
+
     @Override
     public GetAllVehicleDto getAllVehicles() {
-
         List<Vehicle> listOfVehicles = vehicleRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
         List<VehicleDto> responseList = new ArrayList<>();
-
         for (Vehicle vehicle : listOfVehicles) {
             responseList.add(convertToDto(vehicle));
         }
         return new GetAllVehicleDto(responseList);
+    }
+
+    @Override
+    public GetAllVehicleDto getAllPublicVehiclesByLocationId(Long id) {
+        List<Vehicle> vehicles = publicRepository.findPublicAvailableVehicles(id);
+        List<VehicleDto> vehicleDtos = vehicles.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+        return new GetAllVehicleDto(vehicleDtos);
+    }
+
+    @Override
+    public VehicleDto getPublicVehicleById(Long id) {
+        Vehicle vehicle = publicRepository.findById(id)
+                .orElseThrow(() -> new ElementNotFoundException(ELEMENT_VEHICLE));
+            return convertToDto(vehicle);
     }
 
     @Override

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -15,6 +15,8 @@ cors.allowedOrigins=${API_ALLOWED_ORIGINS}
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
+rentalTimeMarginInDays=5
+
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 # Automatically exclude null values from JSON response


### PR DESCRIPTION
 #95 The list of public vehicles now only includes vehicles that aren't customer owned, are available and aren't to be rented out within the coming 5 days. Also added new optional string for public/vehicle with ?locationId=n to see which of these filtered vehicles are available per location.