### PR TITLE
feat: Signout not to use ID in parameter

### DIFF
--- a/main/src/main/java/se/hjulverkstan/main/security/jwt/JwtUtils.java
+++ b/main/src/main/java/se/hjulverkstan/main/security/jwt/JwtUtils.java
@@ -27,8 +27,9 @@ public class JwtUtils {
     @Value("${saveChild.app.jwtExpirationMs}")
     private int jwtExpirationMs;
 
-    public String generateToken(String userName) {
+    public String generateToken(String userName, Long userID) {
         Map<String, Object> claims = new HashMap<>();
+        claims.put("userID", userID);
         return createToken(claims, userName);
     }
 
@@ -49,6 +50,10 @@ public class JwtUtils {
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);
+    }
+
+    public Long extractUserID(String token) {
+        return extractClaim(token, claims -> claims.get("userID", Long.class));
     }
 
     public Date extractExpiration(String token) {

--- a/main/src/main/java/se/hjulverkstan/main/service/CookieServiceImpl.java
+++ b/main/src/main/java/se/hjulverkstan/main/service/CookieServiceImpl.java
@@ -2,6 +2,7 @@ package se.hjulverkstan.main.service;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import se.hjulverkstan.Exceptions.TokenRefreshException;
@@ -12,6 +13,7 @@ import se.hjulverkstan.main.security.jwt.JwtUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+@Log4j2
 @Service
 public class CookieServiceImpl implements CookieService {
     private final JwtUtils jwtUtils;
@@ -28,7 +30,7 @@ public class CookieServiceImpl implements CookieService {
     }
 
     public void createAuthenticationCookies(HttpServletResponse response, UserDetails userDetails) {
-        String jwt = jwtUtils.generateToken(userDetails.getUsername());
+        String jwt = jwtUtils.generateToken(userDetails.getUsername(), userDetails.getId());
         RefreshToken refreshToken = refreshTokenService.createRefreshToken(userDetails.getId());
 
         setJwtCookie(response, jwt);
@@ -40,7 +42,7 @@ public class CookieServiceImpl implements CookieService {
                 .map(refreshTokenService::verifyExpiration)
                 .map(RefreshToken::getUser)
                 .map(user -> {
-                    String jwt = jwtUtils.generateToken(user.getUsername());
+                    String jwt = jwtUtils.generateToken(user.getUsername(), user.getId());
                     RefreshToken refreshToken = refreshTokenService.createRefreshToken(user.getId());
 
                     Map<String, String> tokens = new HashMap<>();

--- a/web/src/components/Auth.tsx
+++ b/web/src/components/Auth.tsx
@@ -71,7 +71,7 @@ export const Provider = ({ children }: AuthProviderProps) => {
       setIsLoading(true);
 
       api
-        .logOut(state.id)
+        .logOut()
         .then(() => setState(null))
         .catch(() =>
           toast(

--- a/web/src/data/auth/api.ts
+++ b/web/src/data/auth/api.ts
@@ -74,8 +74,8 @@ export const logIn = (body: LogInParams) =>
     return res.data;
   });
 
-export const logOut = (id: number) =>
-  instance.post(`${endpoints.auth.logOut}/${id}`).then((res) => {
+export const logOut = () =>
+  instance.post(endpoints.auth.logOut).then((res) => {
     return res.data;
   });
 


### PR DESCRIPTION
Following changes were made:

- Change in frontend, remove id as parameter in calls to logout from `components/Auth.tsx` and `components/Auth.tsx`
- In backend:
- Change `JwtUtils `to have ID as claims to later be extracted, and extraction method
- Change in `AuthController `to extract ID from JwtUtils 
- Change in `CookieServiceImpl` to handle ID in method calls
- Move duplicate in `AuthController` to private method.
- Add `SecurityContextHolder.clearContext()` after signing the user out, in `logoutUser()`, to clear security context. While this is optional and not necessary for stateless APIs, it’s not harmful as long as you're not relying on sessions and can clear up leftover data. Could be useful when doing logging to get cleaner logs, so that old data does not get leaked in logging? Or was this intentionally left out per Hjulverkstan design?

Thoughts and suggestions:

- Having a background in Kotlin with stricter _null safety_, I suggest we could use  `Optional<T>` to handle _nullable_ objects safer. 

  For example `getToken()`...
  
  ```java
  private String getToken(HttpServletRequest request, String type) {
          String token = null;
  
          if (request.getCookies() != null) {
              token = Arrays.stream(request.getCookies())
                      .filter(cookie -> type.equals(cookie.getName()))
                      .findFirst()
                      .map(Cookie::getValue)
                      .orElseThrow(() -> new MissingArgumentException(type + " token"));
          }
  
          return token;
      }
  ```
  ...could be changed to...
  
  ```java
  private Optional<String> getToken(HttpServletRequest request, String type) {
      if (request.getCookies() == null) {
          return Optional.empty();
      }
  
      return Arrays.stream(request.getCookies())
              .filter(cookie -> type.equals(cookie.getName()))
              .findFirst()
              .map(Cookie::getValue);
  }
  ```
  
  ...and in `AuthController.java`...
  
  ```java
  String refreshToken = null;
          try {
              refreshToken = getToken(request, "refreshToken");
          } catch (Exception e) {
              return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new MessageResponse("Cookies are empty or null"));
          }
  ```
  
  ...could...
  
  ```java
  Optional<String> refreshTokenOpt = getToken(request, "refreshToken");
  
      if (refreshTokenOpt.isEmpty()) {
          return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                  .body(new MessageResponse("Cookies are empty or refresh token not found"));
      }
  ```
  
  Could changes of this kind be of use for better null safety, in the future?

- There is some _business logic_ in `AuthController`. Should this  be delegated to Service layer instead? Example, extracting tokens and data from tokens.
- Should we validate the token is not expired in `logoutUser()` before trying to logout the user, or is this 100% unnecessary?