### PR TITLE
feat(): Convert vehicles to customer owned on donate

### DIFF
--- a/api/src/main/java/se/hjulverkstan/main/service/TicketServiceImpl.java
+++ b/api/src/main/java/se/hjulverkstan/main/service/TicketServiceImpl.java
@@ -177,9 +177,22 @@ public class TicketServiceImpl implements TicketService {
             if (!vehicle.getTickets().contains(ticket)) vehicle.getTickets().add(ticket);
         });
 
-        if (ticket instanceof TicketRent || ticket instanceof TicketDonate) {
+        if (ticket instanceof TicketRent) {
             if(vehicles.stream().anyMatch(Vehicle::isCustomerOwned)){
-                throw new UnsupportedTicketVehiclesException("Customer Owned Vehicles cannot be selected for Rental or Donate Tickets!");
+                throw new UnsupportedTicketVehiclesException("Customer Owned Vehicles cannot be selected for Rental Tickets!");
+            }
+            vehicleRepository.saveAll(vehicles);
+        }
+
+        if (ticket instanceof TicketDonate) {
+            if(vehicles.stream().anyMatch(Vehicle::isCustomerOwned)) {
+                throw new UnsupportedTicketVehiclesException("Customer Owned Vehicles cannot be selected for Donate Tickets!");
+            }
+
+            for (Vehicle vehicle : vehicles) {
+                vehicle.setCustomerOwned(true);
+                vehicle.setRegTag(null);
+                vehicle.setVehicleStatus(VehicleStatus.ARCHIVED);
             }
             vehicleRepository.saveAll(vehicles);
         }

--- a/web/src/components/ConfirmConvertDialog.tsx
+++ b/web/src/components/ConfirmConvertDialog.tsx
@@ -1,0 +1,79 @@
+import {
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@components/shadcn/Dialog';
+import { Button, IconButton } from '@components/shadcn/Button';
+import { RepeatIcon } from 'lucide-react';
+import React, { useMemo } from 'react';
+import BadgeGroup, { Badge } from '@components/BadgeGroup';
+import { capitalize } from '@utils';
+import { useVehiclesQ } from '@data/vehicle/queries';
+
+interface confirmConvertDialogProps {
+  title: string;
+  description?: string;
+  onConfirm: (arg: any) => void;
+  onClose?: () => void;
+  vehicleIds: string[];
+}
+
+export default function ConfirmConvertDialog({
+  title,
+  description,
+  onConfirm,
+  onClose,
+  vehicleIds,
+}: confirmConvertDialogProps) {
+  const vehiclesQ = useVehiclesQ();
+
+  const badges: Badge[] = useMemo(
+    () =>
+      !vehiclesQ.data
+        ? []
+        : vehicleIds
+            .map((id) => vehiclesQ.data.find((v) => v.id === id))
+            .filter((v) => !!v)
+            .map((v) => ({
+              label: v.isCustomerOwned ? `#${v.id}` : v.regTag,
+              variant: 'secondary',
+              tooltip: capitalize(v.vehicleType),
+            })),
+    [vehiclesQ.data],
+  );
+
+  return (
+    <DialogContent className="flex flex-col sm:max-w-[425px]">
+      <DialogHeader>
+        <DialogTitle>{`${title}`}</DialogTitle>
+
+        <DialogDescription>{`${description}`}</DialogDescription>
+        <div className="w-full pt-1.5 [&>div]:flex-wrap">
+          <BadgeGroup limit={20} badges={badges} />
+        </div>
+      </DialogHeader>
+
+      <DialogFooter>
+        {onClose && (
+          <DialogClose asChild>
+            <Button variant="outline" type="button" onClick={onClose}>
+              Cancel
+            </Button>
+          </DialogClose>
+        )}
+        <DialogClose asChild>
+          <IconButton
+            variant={'red'}
+            type="submit"
+            onClick={onConfirm}
+            icon={RepeatIcon}
+            text="Convert"
+          />
+        </DialogClose>
+      </DialogFooter>
+    </DialogContent>
+  );
+}


### PR DESCRIPTION
When creating a donate ticket, the selected vehicles are now converted to customer owned, their regTags are nulled and then they are archived.

Resolves #82