### PR TITLE
fix: make brand optional

### DIFF
--- a/api/src/main/java/se/hjulverkstan/main/dto/vehicles/EditVehicleBikeDto.java
+++ b/api/src/main/java/se/hjulverkstan/main/dto/vehicles/EditVehicleBikeDto.java
@@ -24,7 +24,6 @@ public class EditVehicleBikeDto extends EditVehicleDto {
     @NotNull(message = "Brake type is required")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private VehicleBrakeType brakeType;
-    @NotNull(message = "Brand is required")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private VehicleBrand brand;
 

--- a/api/src/main/java/se/hjulverkstan/main/dto/vehicles/NewVehicleBikeDto.java
+++ b/api/src/main/java/se/hjulverkstan/main/dto/vehicles/NewVehicleBikeDto.java
@@ -27,7 +27,6 @@ public class NewVehicleBikeDto extends NewVehicleDto {
     @NotNull(message = "Brake type is required")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private VehicleBrakeType brakeType;
-    @NotNull(message = "Brand is required")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private VehicleBrand brand;
 

--- a/api/src/main/java/se/hjulverkstan/main/dto/vehicles/VehicleBikeDto.java
+++ b/api/src/main/java/se/hjulverkstan/main/dto/vehicles/VehicleBikeDto.java
@@ -28,7 +28,6 @@ public class VehicleBikeDto extends VehicleDto {
     @NotNull(message = "Brake type is required")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private VehicleBrakeType brakeType;
-    @NotNull(message = "Brand is required")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private VehicleBrand brand;
 

--- a/web/src/components/DataForm/DataFormSelect.tsx
+++ b/web/src/components/DataForm/DataFormSelect.tsx
@@ -16,6 +16,7 @@ export interface SelectProps extends Omit<FieldProps, 'children'> {
   isMultiSelect?: boolean;
   disabled?: boolean;
   fat?: boolean;
+  allowDeselect?: boolean;
 }
 
 export const Select = ({
@@ -26,6 +27,7 @@ export const Select = ({
   description,
   disabled,
   fat,
+  allowDeselect,
 }: SelectProps) => {
   const { isLoading, body, setBodyProp, isDisabled } = useDataForm();
   const [open, setOpen] = useState(false);
@@ -72,7 +74,11 @@ export const Select = ({
             });
             setBodyProp(dataKey, updatedBody);
           } else {
-            setBodyProp(dataKey, e.value);
+            if (allowDeselect && isSelected) {
+              setBodyProp(dataKey, undefined);
+            } else {
+              setBodyProp(dataKey, e.value);
+            }
             setOpen(false);
           }
         }}
@@ -113,7 +119,9 @@ export const Select = ({
               ? ''
               : hasData
                 ? buttonLabel
-                : `Select ${label.toLowerCase()}...`}
+                : allowDeselect
+                  ? `No ${label.toLowerCase()} selected...`
+                  : `Select ${label.toLowerCase()}...`}
             <CaretSortIcon className="ml-auto h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </Popover.Trigger>

--- a/web/src/data/vehicle/form.ts
+++ b/web/src/data/vehicle/form.ts
@@ -58,7 +58,7 @@ export function useVehicleZ() {
             ...commonProps,
             vehicleType: z.literal(VehicleType.BIKE),
             bikeType: z.nativeEnum(BikeType, isReq('Bike Type')),
-            brand: z.nativeEnum(BikeBrand, isReq('Brand')),
+            brand: z.nativeEnum(BikeBrand).optional(),
             size: z.nativeEnum(BikeSize, isReq('Size')),
             brakeType: z.nativeEnum(BrakeType, isReq('Brake Type')),
             gearCount: z

--- a/web/src/root/Portal/PortalShopInventory/ShopInventoryFields.tsx
+++ b/web/src/root/Portal/PortalShopInventory/ShopInventoryFields.tsx
@@ -107,6 +107,7 @@ export default function ShopInventoryFields() {
               label="Brand"
               dataKey="brand"
               enums={enums.brand}
+              allowDeselect
             />
             <DataForm.Select label="Size" dataKey="size" enums={enums.size} />
             <DataForm.Select


### PR DESCRIPTION
# Description
The brand was made optional, both in the form.ts and in the respective dtos.

## Explanation
- The notations in DTOs that made the brand field mandatory when creating objects have been removed.
- The zod object that defined the Vehicle has been modified to accept brand as optional.
- The Select field has been modified to allow deselecting an option and, if this option is enabled, to display a different placeholder.

Solves #274 