### PR TITLE
fix(web): move heading on VehicleDetail from Page to SectionContent

### DIFF
--- a/web/src/components/Page.tsx
+++ b/web/src/components/Page.tsx
@@ -21,14 +21,12 @@ export interface PageProps extends VariantProps<typeof pageStyles> {
   children: ReactNode;
   hasHeroSection?: boolean;
   heading?: string;
-  useH2?: boolean;
 }
 
 export const Page = ({
   children,
   hasHeroSection,
   heading,
-  useH2,
   variant,
 }: PageProps) => (
   <>
@@ -39,7 +37,7 @@ export const Page = ({
           className="mx-auto -mb-8 w-[88vw] max-w-[1852px] pt-28 md:-mb-16
             md:pt-16"
         >
-          {useH2 ? <h2>{heading}</h2> : <h1>{heading}</h1>}
+          <h1>{heading}</h1>
         </div>
       )}
       {children}

--- a/web/src/root/VehicleDetail.tsx
+++ b/web/src/root/VehicleDetail.tsx
@@ -138,9 +138,12 @@ export default function VehicleDetail() {
     setVisibleCount((prevCount) => prevCount + ITEMS_TO_LOAD_OTHER_BIKES);
 
   return (
-    <Page heading={vehicleQ.data?.label} useH2 variant="muted">
+    <Page variant="muted">
       <Section variant="muted" className="md:pb-20">
-        <SectionContent className="max-w-[1280px]">
+        <SectionContent
+          heading={vehicleQ.data?.label}
+          className="max-w-[1280px]"
+        >
           <div
             className="bg-secondary mb-8 hidden w-full flex-col rounded-lg
               sm:flex-row sm:items-stretch sm:justify-around md:flex lg:p-4"
@@ -154,7 +157,8 @@ export default function VehicleDetail() {
                 <ImageWithFallback
                   src={vehicleQ.data.imageURL}
                   alt={vehicleQ.data.regTag}
-                  className="aspect-[16/9] h-auto w-full rounded-lg object-cover"
+                  className="aspect-[16/9] h-auto w-full rounded-lg
+                    object-cover"
                   fallback={
                     <Error
                       className="bg-secondary aspect-[16/9] h-full"
@@ -232,7 +236,9 @@ export default function VehicleDetail() {
           <SectionContent
             heading={preloadedData.generalContent.sectionTitleOtherBikesText}
           >
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            <div
+              className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3"
+            >
               {otherVehicles.slice(0, visibleCount).map((vehicle) => {
                 return (
                   <CardVehicle key={vehicle.id} vehicle={vehicle} shop={shop} />


### PR DESCRIPTION
Remove related fix on Page since heading is now handled in SectionContent.