### PR TITLE
feat(web): Reduce required fields in portal

### DIFF
--- a/api/src/main/java/se/hjulverkstan/main/feature/customer/CustomerDto.java
+++ b/api/src/main/java/se/hjulverkstan/main/feature/customer/CustomerDto.java
@@ -44,7 +44,6 @@ public class CustomerDto extends AuditableDto {
     @NotBlank(message = "Customer phone number is required")
     private String phoneNumber;
 
-    @NotBlank(message = "Customer email is required")
     @Email(message = "Customer email must be valid")
     private String email;
 

--- a/api/src/main/java/se/hjulverkstan/main/feature/vehicle/VehicleUtils.java
+++ b/api/src/main/java/se/hjulverkstan/main/feature/vehicle/VehicleUtils.java
@@ -25,7 +25,7 @@ public class VehicleUtils {
             if (dto.getBatchCount() == null) throw new MissingArgumentException("batchCount");
         }
 
-        if (dto.getVehicleType() == VehicleType.BIKE) {
+        if (dto.getVehicleType() == VehicleType.BIKE && !dto.isCustomerOwned()) {
             if (dto.getBikeType() == null) throw new MissingArgumentException("bikeType");
             if (dto.getGearCount() == null) throw new MissingArgumentException("gearCount");
             if (dto.getSize() == null) throw new MissingArgumentException("size");

--- a/web/src/components/DataForm/DataFormCollapsible.tsx
+++ b/web/src/components/DataForm/DataFormCollapsible.tsx
@@ -12,12 +12,14 @@ export interface CollapsibleProps {
 }
 
 export const Collapsible = ({ label, children }: CollapsibleProps) => {
-  const { isDisabled, mode } = useDataForm();
-  const [isOpen, setIsOpen] = useState(mode === Mode.CREATE);
+  const { isDisabled, mode, body } = useDataForm();
+
+  const shouldBeOpen = mode === Mode.CREATE && !body.isCustomerOwned;
+  const [isOpen, setIsOpen] = useState(shouldBeOpen);
 
   useEffect(() => {
-    if (mode === Mode.CREATE) setIsOpen(true);
-  }, [mode]);
+    setIsOpen(shouldBeOpen);
+  }, [mode, body.isCustomerOwned]);
 
   return (
     <ShadCollapsible.Root open={isOpen} onOpenChange={setIsOpen}>
@@ -25,7 +27,7 @@ export const Collapsible = ({ label, children }: CollapsibleProps) => {
         <div
           className={C.cn(
             `align-center space-between text flex cursor-pointer items-center
-rounded-md border px-4 py-2 text-sm font-medium`,
+            rounded-md border px-4 py-2 text-sm font-medium`,
             isDisabled && '!opacity-75',
           )}
         >

--- a/web/src/data/customer/form.ts
+++ b/web/src/data/customer/form.ts
@@ -11,9 +11,11 @@ const customerBaseZ = z.object({
   firstName: reqString('First name'),
   lastName: reqString('Last name'),
   phoneNumber: reqString('Phone number'),
-  email: reqString('Email').email({
-    message: 'The email is not a valid email address',
-  }),
+  email: z
+    .string()
+    .email({ message: 'Email is not valid' })
+    .or(z.literal(''))
+    .optional(),
 });
 
 export const customerZ = z.discriminatedUnion('customerType', [


### PR DESCRIPTION
When creating a new vehicle object and ownership is set to customer, the required fields are now, location, ownership type and vehicle type. Dropdown defaults to closed when ownership is customer. Email is no longer required when creating a new customer.

#365