### PR TITLE
feat(web): Enable localized story titles in admin portal

### DIFF
--- a/web/src/root/Portal/PortalWebEditStories/WebEditStoriesFields.tsx
+++ b/web/src/root/Portal/PortalWebEditStories/WebEditStoriesFields.tsx
@@ -15,13 +15,6 @@ export default function WebEditStoriesFields() {
       />
 
       <DataForm.Input
-        placeholder="Write title..."
-        label="Title"
-        dataKey="title"
-        disabled={lang !== Global}
-      />
-
-      <DataForm.Input
         placeholder="Write slug (url)..."
         label="Slug"
         dataKey="slug"
@@ -29,11 +22,20 @@ export default function WebEditStoriesFields() {
       />
 
       {lang !== Global && (
-        <DataForm.RichText
-          variant="translation"
-          label="Body Text"
-          dataKey="bodyText"
-        />
+        <>
+          <DataForm.Input
+            placeholder="Write title..."
+            variant="translation"
+            label="Title"
+            dataKey="title"
+          />
+
+          <DataForm.RichText
+            variant="translation"
+            label="Body Text"
+            dataKey="bodyText"
+          />
+        </>
       )}
     </>
   );

--- a/web/src/root/Portal/PortalWebEditStories/useColumns.tsx
+++ b/web/src/root/Portal/PortalWebEditStories/useColumns.tsx
@@ -18,12 +18,6 @@ export default function useColumns() {
     () =>
       [
         {
-          key: 'title',
-          name: 'Title',
-          renderFn: ({ title }) => <IconLabel label={title} />,
-        },
-
-        {
           key: 'slug',
           name: 'Slug',
           renderFn: ({ slug }) => <IconLabel label={slug} />,
@@ -31,6 +25,22 @@ export default function useColumns() {
 
         ...(lang != Global
           ? ([
+              {
+                key: 'title',
+                name: 'Title',
+                renderFn: ({ title }) => (
+                  <IconLabel
+                    className={'text-muted-foreground'}
+                    label={title}
+                  />
+                ),
+                renderHeaderFn: () => (
+                  <PortalWebEditTranslationSortHead
+                    colKey="title"
+                    label="Title"
+                  />
+                ),
+              },
               {
                 key: 'bodyText',
                 name: 'Body text',


### PR DESCRIPTION
The story title field was previously disabled as localization was not supported. This update enables the field and updates its visual 
appearance to align with multi-language input standards.
Solves #421