### PR TITLE
fix(cdk): Intermittent 403 AccessDenied errors

### DIFF
--- a/cdk/lib/app.ts
+++ b/cdk/lib/app.ts
@@ -221,6 +221,21 @@ export class AppStack extends cdk.Stack {
       domainNames: [props.config.siteDomain],
       certificate,
 
+      errorResponses: [
+        {
+          httpStatus: 403,
+          responseHttpStatus: 200,
+          responsePagePath: '/index.html',
+          ttl: cdk.Duration.minutes(0),
+        },
+        {
+          httpStatus: 404,
+          responseHttpStatus: 200,
+          responsePagePath: '/index.html',
+          ttl: cdk.Duration.minutes(0),
+        },
+      ],
+
       defaultBehavior: {
         origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,


### PR DESCRIPTION
Added custom error responses for HTTP 403 and 404 to serve /index.html with a 200 OK status. This allows the client-side router to handle deep-linked URLs and page refreshes instead of S3 returning an Access Denied XML response.