### PR TITLE
fix(web): Fix location selection collision and add type filtering

### DIFF
--- a/web/src/components/DataForm/DataFormSelect.tsx
+++ b/web/src/components/DataForm/DataFormSelect.tsx
@@ -64,8 +64,8 @@ export const Select = ({
 
     return (
       <Command.Item
-        key={e.label}
-        value={e.label}
+        key={e.value}
+        value={e.value}
         onSelect={() => {
           if (isMultiSelect) {
             const updatedBody = C.toUpdatedArray(getBodyProp(dataKey), {

--- a/web/src/data/location/queries.ts
+++ b/web/src/data/location/queries.ts
@@ -32,17 +32,25 @@ export const useLocationQ = ({ id }: UseLocationQProps) =>
 
 //
 
-export const useLocationsAsEnumsQ = ({ dataKey = 'locationId' } = {}) => {
+export const useLocationsAsEnumsQ = ({
+  dataKey = 'locationId',
+  allowedTypes,
+}: { dataKey?: string; allowedTypes?: string[] } = {}) => {
   const enums = useTranslateRawEnums(enumsRaw);
 
   return useQuery<Location[], StandardError, EnumAttributes[]>({
     ...api.createGetLocations(),
     select: (locations) =>
-      locations?.map((location) => ({
-        dataKey,
-        icon: findEnum(enums, location.locationType).icon,
-        label: location.name,
-        value: location.id,
-      })) ?? [],
+      locations
+        ?.filter(
+          (location) =>
+            !allowedTypes || allowedTypes.includes(location.locationType),
+        )
+        .map((location) => ({
+          dataKey,
+          icon: findEnum(enums, location.locationType).icon,
+          label: location.name,
+          value: location.id,
+        })) ?? [],
   });
 };

--- a/web/src/root/Portal/PortalShopTickets/ShopTicketsFields.tsx
+++ b/web/src/root/Portal/PortalShopTickets/ShopTicketsFields.tsx
@@ -26,7 +26,7 @@ export default function ShopTicketFields() {
 
   const employeeEnumsQ = useEmployeesAsEnumsQ();
   const customerEnumsQ = useCustomersAsEnumsQ();
-  const locationEnumsQ = useLocationsAsEnumsQ();
+  const locationEnumsQ = useLocationsAsEnumsQ({ allowedTypes: ['SHOP'] });
 
   let filterCustomerOwned;
 


### PR DESCRIPTION
Updated Select component to use unique 'value' (ID) instead of 'label' as the identifier for Command items to prevent visual selection collision. Refactor useLocationsAsEnumsQ to support 'allowedTypes' for filtering and ensured only 'SHOP' is available for tickets while both 'SHOP' and 'STORAGE' remain available for vehicles. Solves #444