### PR TITLE
fix(web): CreatedAt filter for Tickets

### DIFF
--- a/web/src/root/Portal/PortalShopTickets/useColumns.tsx
+++ b/web/src/root/Portal/PortalShopTickets/useColumns.tsx
@@ -173,7 +173,7 @@ export default function useColumns() {
         },
 
         {
-          key: 'createdat',
+          key: 'createdAt',
           name: 'Created at',
           renderFn: ({ createdAt }) => (
             <IconLabel label={format(new Date(createdAt), 'yyyy-MM-dd')} />
@@ -181,11 +181,12 @@ export default function useColumns() {
         },
 
         {
-          key: 'updatedat',
+          key: 'updatedAt',
           name: 'Edited at',
-          renderFn: ({ updatedAt }) => updatedAt && (
-            <IconLabel label={format(new Date(updatedAt), 'yyyy-MM-dd')} />
-          ),
+          renderFn: ({ updatedAt }) =>
+            updatedAt && (
+              <IconLabel label={format(new Date(updatedAt), 'yyyy-MM-dd')} />
+            ),
         },
       ] as Array<DataTable.Column<TicketAggregated>>,
     [


### PR DESCRIPTION
The filter for createdAt and updatedAt did not work in the Portal Inventory.