### PR TITLE
feat(web): Dialog for Rent-button in VehicleDetail

### DIFF
--- a/web/src/data/translations/en.ts
+++ b/web/src/data/translations/en.ts
@@ -24,6 +24,7 @@ export default {
   sunday: 'Sunday',
 
   findShop: 'Find shop',
+  toShop: 'To shop',
   findEvent: 'Find event',
 
   loadMore: 'Load more',

--- a/web/src/data/translations/sv.ts
+++ b/web/src/data/translations/sv.ts
@@ -24,6 +24,7 @@ export default {
   sunday: 'Söndag',
 
   findShop: 'Hitta verkstad',
+  toShop: 'Till verkstad',
   findEvent: 'Hitta evenemang',
 
   loadMore: 'Ladda fler',

--- a/web/src/root/Services.tsx
+++ b/web/src/root/Services.tsx
@@ -69,16 +69,19 @@ export const ServicesRepairCardView: React.FC<{
 
 export const ServicesHowToRentView: React.FC<{
   mode?: 'page' | 'dialog';
-}> = ({ mode = 'page' }) => {
+  endpoint?: string;
+  label?: boolean;
+}> = ({ mode = 'page', endpoint, label }) => {
   const { data } = usePreloadedDataLocalized();
+  const { t } = useTranslations();
 
   return (
     <CardServices
       mode={mode}
       title={data.text.servicesHowToRent}
       icon={Bike}
-      linkLabel={data.text.servicesFindShop}
-      linkDestination="/shops"
+      linkLabel={label ? t('toShop') : data.text.servicesFindShop}
+      linkDestination={endpoint ? `/shops/${endpoint}` : '/shops'}
       a11yTitle={data.text.servicesHowToRent}
       a11yDescription={data.text.servicesHowToRent}
     >

--- a/web/src/root/VehicleDetail.tsx
+++ b/web/src/root/VehicleDetail.tsx
@@ -29,6 +29,8 @@ import { useTranslateRawEnums } from '@hooks/useTranslateRawEnums';
 import * as enumsRaw from '@data/vehicle/enums';
 import { useTranslations } from '@hooks/useTranslations';
 import { findEnum } from '@utils/enums';
+import { ServicesAsDialogWrapper, ServicesHowToRentView } from './Services';
+import { useDialogManager } from '@components/DialogManager';
 
 const ITEMS_TO_LOAD_OTHER_BIKES = 3;
 
@@ -56,7 +58,7 @@ const VehicleAttribute = ({
 
 const ShopRentalSection = ({ shop }: { shop: any }) => {
   const { data } = usePreloadedDataLocalized();
-
+  const { openDialog } = useDialogManager();
   const { t } = useTranslations();
 
   return (
@@ -100,6 +102,17 @@ const ShopRentalSection = ({ shop }: { shop: any }) => {
           size="default"
           className="bg-green-accent text-background hover:bg-success-accent
             rounded-full"
+          onClick={() =>
+            openDialog(
+              <ServicesAsDialogWrapper>
+                <ServicesHowToRentView
+                  mode="dialog"
+                  endpoint={shop.slug}
+                  label={true}
+                />
+              </ServicesAsDialogWrapper>,
+            )
+          }
         />
       </div>
     </>


### PR DESCRIPTION
Added a dialog for the rent button on the vehicle page. The dialog ensures that the user is redirected back to the shop. Solves #343