### PR TITLE
fix(web): Update select component search index

### DIFF
--- a/web/src/components/DataForm/DataFormSelect.tsx
+++ b/web/src/components/DataForm/DataFormSelect.tsx
@@ -65,7 +65,7 @@ export const Select = ({
     return (
       <Command.Item
         key={e.value}
-        value={e.value}
+        value={`${e.label}${e.value}`}
         onSelect={() => {
           if (isMultiSelect) {
             const updatedBody = C.toUpdatedArray(getBodyProp(dataKey), {


### PR DESCRIPTION
The search input now matches against the visible label. Previously, it only indexed the ID (value), making it impossible for users to search for names. Solves #471