### PR TITLE
fix(api): Remove manual ID setter in applyoEntity

### DIFF
--- a/api/src/main/java/se/hjulverkstan/main/feature/ticket/TicketDto.java
+++ b/api/src/main/java/se/hjulverkstan/main/feature/ticket/TicketDto.java
@@ -83,7 +83,6 @@ public class TicketDto extends AuditableDto {
     }
 
     public Ticket applyToEntity (Ticket ticket, List<Vehicle> vehicles, Location location, Employee employee, Customer customer) {
-        ticket.setId(id);
         ticket.setTicketType(ticketType);
         ticket.setStartDate(ticketType == TicketType.RENT ? startDate : null);
         ticket.setEndDate(ticketType == TicketType.RENT ? endDate : null);

--- a/api/src/main/java/se/hjulverkstan/main/feature/ticket/TicketService.java
+++ b/api/src/main/java/se/hjulverkstan/main/feature/ticket/TicketService.java
@@ -110,7 +110,7 @@ public class TicketService {
 
     private void applyToEntity(Ticket ticket, TicketDto dto, List<Vehicle> vehicles) {
         Location location = locationRepository.findById(dto.getLocationId())
-                .orElseThrow(() -> new ElementNotFoundException("Location with id: " + dto.getEmployeeId()));
+                .orElseThrow(() -> new ElementNotFoundException("Location with id: " + dto.getLocationId()));
 
         Employee employee = employeeRepository.findById(dto.getEmployeeId())
                 .orElseThrow(() -> new ElementNotFoundException("Employee with id: " + dto.getEmployeeId()));


### PR DESCRIPTION
This fixes the internal 500 error when editing tickets, where Hibernate detected an illegal identity change during the transaction. Solves #461