### PR TITLE
fix(api): Remove @NotBlank from password in UserDto

### DIFF
--- a/api/src/main/java/se/hjulverkstan/main/feature/user/UserDto.java
+++ b/api/src/main/java/se/hjulverkstan/main/feature/user/UserDto.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import se.hjulverkstan.main.security.model.ERole;
 import se.hjulverkstan.main.security.model.Role;
 import se.hjulverkstan.main.shared.auditable.AuditableDto;
@@ -32,7 +31,6 @@ public class UserDto extends AuditableDto {
     private String email;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-    @NotBlank(message = "Password is required")
     @Size(min = 3, max = 120)
     transient private String password;
 


### PR DESCRIPTION
To be able to edit users without changing their password. Zod is not letting you create a new user without a password so that will not be a problem.