### PR TITLE
fix(web): Zod stories schema failing

### DIFF
--- a/web/src/data/webedit/story/form.ts
+++ b/web/src/data/webedit/story/form.ts
@@ -10,5 +10,5 @@ export const createStoryZ = () =>
     title: reqString('Title'),
     slug: reqString('Slug (web url)'),
     imageURL: z.string().optional(),
-    bodyText: z.record(z.any()).nullable().optional(),
+    bodyText: z.record(z.string(), z.any()).nullable().optional(),
   });


### PR DESCRIPTION
After updating our packages, z.record() needed 2-3 arguments.